### PR TITLE
Update doctr deploy API usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ install:
 
 script:
   - regolith build html;
-    doctr deploy --deploy-repo ergs/twofcs.ergs.sc.edu --gh-pages-docs ".";
+    doctr deploy --deploy-repo ergs/twofcs.ergs.sc.edu .;
 


### PR DESCRIPTION
Deploy directory is now a required argument and the `-gh-pages-docs` flag is deprecated.