### PR TITLE
Update doctr deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ install:
 
 script:
   - regolith build html;
-    doctr deploy --deploy-repo ergs/twofcs.ergs.sc.edu --gh-pages-docs ".";
+    doctr deploy --deploy-repo ergs/twofcs.ergs.sc.edu .;
 


### PR DESCRIPTION
The `--gh-pages-docs` flag is deprecated and the deploy directory is now a required argument.